### PR TITLE
Remove solc version in deploy.py, add instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://github.com/bloxberg-org/cert-tools
 ## How deploying smart contract works
 
 After deploying the contract, the cert-deployer links the contract to the potential
-issuer's ENS domain – more specific sets the contract's address as the ENS entry's
+issuer's ENS domain [(?)](https://decrypt.co/resources/ethereum-name-service-ens-explained-guide-learn) – more specific sets the contract's address as the ENS entry's
 address attribute. This input, can, of course, be changed when deploying another
 contract, but please note that addresses can only be overwritten, since the ENS
 domain can point to only one (contract) address.
@@ -26,14 +26,14 @@ explained a bit more in detail below.
 
 ### Prerequisites
 
-We highly recommend to use the cert-deployer within a virtual environment! After
+We highly recommend to use the cert-deployer within a virtual environment! See [recommendations](https://github.com/bloxberg-org/cert-issuer/blob/master/docs/virtualenv.md). After
 activating the virtual environment, please execute:
 
 `$ python setup.py install`
 
 All necessary dependencies will be installed afterwards. Further required are also
 the setups of an Ethereum wallet (the wallet has to be registered in the Ethereum
-chain that being intended to be used later) and an according ENS domain.
+chain that being intended to be used later).
 
 Our recommended tool for creating and managing the wallet is [Metamask](https://metamask.io).
 
@@ -45,37 +45,41 @@ adjusting the smart contract). The conf_template.ini file includes the following
 ```
 deploying_address = <Your Ethereum address>
 
-chain = <ethereum_ropsten|ethereum_mainnet>
+chain = <ethereum_ropsten|ethereum_mainnet|bloxberg>
 node_url = <ethereum web3 public node url (e.g. infura)>
 
 ens_name = <Your ENS name registered with your ethereum address>
 overwrite_ens_link = <Do you want to overwrite a present link to a smart contract? True/False>
 
-usb_name= </Volumes/path-to-usb/>
-key_file= <file-you-saved-pk-to>
+# usb_name is the folder where the private key is and key_file is the file name.
+usb_name= <path-to-keyfile-folder>
+key_file= <keyfile-file-name>
 ```
 
 Notes:
+
 1. The ethereum address corresponds to the respective wallet address.
+1. The private key file [should be](https://eth-account.readthedocs.io/en/latest/eth_account.html#eth_account.account.Account.from_key) a raw private key: a hex str, bytes or int
 1. Potential issuers can set up their own infura nodes or use publicly shared ones.
 1. If a smart contract shall be deployed and used by an already to another contract
-linked ENS name, the `overwrite_ens_link` has to be  set to `True` in order to prevent
-accidental overwriting.
+   linked ENS name, the `overwrite_ens_link` has to be set to `True` in order to prevent
+   accidental overwriting.
 1. The cert-deployer uses a separate class to access the wallet's private key which
-should be stored under the path provided. Ideally, that location is not permanently
-accessible (e.g. USB stick) improving security.
+   should be stored under the path provided. Ideally, that location is not permanently
+   accessible (e.g. USB stick) improving security.
 
-Rename the conf_template.ini to conf_eth.ini once filled with your parameters
+Rename the conf_template.ini to conf_eth.ini once filled with your parameters. You can find the existing bloxberg config in `conf_eth.ini` of this repository.
 
 ### Quick steps
 
 Execute these instructions step-by-step:
+
 1. ensure you have installed [solidity compiler (solc)](https://solidity.readthedocs.io/en/v0.5.3/installing-solidity.html)
 1. clone github repo `$ git clone https://github.com/bloxberg-org/cert-deployer.git`
+1. Activate virtual environment `$ virtualenv <virtual_env_name>/bin/activate`
 1. install dependencies within virtualenv `$ python setup.py install`
 1. add required information incl. paths and connection data into conf_eth.ini
 1. deploy smart contract `$ python cert_deployer/deploy.py`
 
 ... install the forked cert-issuer- (and cert-tools) repositories for benefitting
 from the whole framework (links above).
-

--- a/cert_deployer.egg-info/PKG-INFO
+++ b/cert_deployer.egg-info/PKG-INFO
@@ -9,24 +9,16 @@ License: MIT
 Description: # cert-deployer
         
         This project deploys smart contracts to the Ethereum blockchain enabling the
-        cert-issuer to modify a certificates' or certificate batches' status respectively,
-        i.e. to issue or revoke, and the cert-verifier to get that status in order to verify
-        its validity.
+        cert-issuer to modify a certificates' or certificate batches' status respectively.
         
-        The related forked repositories of the original cert-issuer and cert-verifier are linked
+        The related forked repositories of the original cert-issuer and cert-tools are linked
         below.
         
-        https://github.com/BlockcertsSmartContract/cert-issuer
+        https://github.com/bloxberg-org/cert-issuer
         
-        https://github.com/BlockcertsSmartContract/cert-verifier
+        https://github.com/bloxberg-org/cert-tools
         
         ## How deploying smart contract works
-        
-        Potential issuers find our suggested sample contract in the data directory which
-        gets, first, compiled from source and, second, deployed afterwards. This contracts is, again,
-        just a suggestion and can of course be modified without limiting the codes functionality
-        – adequate modifications implied (note that some adjustments of the cert-issuer and verifier
-         may be required as a consequence).
         
         After deploying the contract, the cert-deployer links the contract to the potential
         issuer's ENS domain – more specific sets the contract's address as the ENS entry's
@@ -42,7 +34,7 @@ Description: # cert-deployer
         
         ### Prerequisites
         
-        We highly recommend to use the cert-deployer within a virtual environment! After
+        We highly recommend to use the cert-deployer within a virtual environment! See [recommendations](https://github.com/bloxberg-org/cert-issuer/blob/master/docs/virtualenv.md). After
         activating the virtual environment, please execute:
         
         `$ python setup.py install`
@@ -51,15 +43,12 @@ Description: # cert-deployer
         the setups of an Ethereum wallet (the wallet has to be registered in the Ethereum
         chain that being intended to be used later) and an according ENS domain.
         
-        Our recommended tool for creating and managing the wallet is [Metamask](https://metamask.io)
-        which is, used as its chrome extension, an at least very viable option for an
-        efficient ENS name registration using the [web application](https://app.ens.domains/). Please make sure that
-        your wallet has access to a sufficient amount of ether any time.
+        Our recommended tool for creating and managing the wallet is [Metamask](https://metamask.io).
         
         ### Configuring cert-deployer
         
         The last step to be executed is completing the configuration inputs (optional:
-        adjusting the smart contract). The conf_eth.ini file includes the following parameters:
+        adjusting the smart contract). The conf_template.ini file includes the following parameters:
         
         ```
         deploying_address = <Your Ethereum address>
@@ -75,56 +64,29 @@ Description: # cert-deployer
         ```
         
         Notes:
+        
         1. The ethereum address corresponds to the respective wallet address.
         1. Potential issuers can set up their own infura nodes or use publicly shared ones.
         1. If a smart contract shall be deployed and used by an already to another contract
-        linked ENS name, the `overwrite_ens_link` has to be  set to `True` in order to prevent
-        accidental overwriting.
+           linked ENS name, the `overwrite_ens_link` has to be set to `True` in order to prevent
+           accidental overwriting.
         1. The cert-deployer uses a separate class to access the wallet's private key which
-        should be stored under the path provided. Ideally, that location is not permanently
-        accessible (e.g. USB stick) improving security.
+           should be stored under the path provided. Ideally, that location is not permanently
+           accessible (e.g. USB stick) improving security.
         
-        ### Long story short
+        Rename the conf_template.ini to conf_eth.ini once filled with your parameters
+        
+        ### Quick steps
         
         Execute these instructions step-by-step:
+        
         1. ensure you have installed [solidity compiler (solc)](https://solidity.readthedocs.io/en/v0.5.3/installing-solidity.html)
-        1. clone github repo `$ git clone https://github.com/BlockcertsSmartContract/cert-deployer.git`
+        1. clone github repo `$ git clone https://github.com/bloxberg-org/cert-deployer.git`
         1. install dependencies within virtualenv `$ python setup.py install`
         1. add required information incl. paths and connection data into conf_eth.ini
-        1. deploy smart contract `$ python deploy.py`
+        1. deploy smart contract `$ python cert_deployer/deploy.py`
         
-        ... install the forked cert-issuer- (and cert-verifier) repositories for benefitting
+        ... install the forked cert-issuer- (and cert-tools) repositories for benefitting
         from the whole framework (links above).
-        
-        ## Why use cert-deployer
-        
-        While it is possible to deploy batches to the Ethereum blockchain separately, it
-        is impossible to modify associated information as e.g. attributes, since the data,
-        once deployed,is immutable by nature. As certificates could be revoked eventually,
-        [BlockCerts](https://github.com/blockchain-certificates) has addressed this issue
-        with external server provided revocation lists. Unfortunately, the cert-verifier's
-        functionality is, as a consequence, limited by either temporal or permanent offline
-        times of these servers. Due to its resulting inability distinguishing between valid
-        and invalid certificates this design destroys especially the processes availability
-        guarantee naturally coming with the use of blockchains.
-        
-        In order to restore i.a. the availability guarantee over the entire certificates'
-        lifetime, we provide an extension of the existing Blockcerts implementation that
-        issues and revokes certificates using a smart contracts mapping ability, thus making
-        a certificates' (or batches') status editable after being deployed (excl. for the
-        issuer).
-        
-        Another similar issue is the original identity management including the publication
-        of issuer identities (public keys) on external servers. This is mostly disadvantageous
-        in case of a permanent server shutdown requiring the public key to have become public
-        knowledge in the meantime. Otherwise, all future verifications of associated certificates
-        would become impossible. The usage of the Ethereum name service constitutes an
-        efficient option solving that problem, since the according assertion of a public
-        key and ENS domain could be e.g. stored within the contract itself so that this
-        information does not get lost over time.
-        
-        In conclusion, using the cert-deployer, paired with the cert-issuer and -verifier
-        linked above, the natural blockchain guarantees are restored by moving the revocation
-        and identity administration to the blockchain – i.e. to a smart contract.
         
 Platform: UNKNOWN

--- a/cert_deployer.egg-info/requires.txt
+++ b/cert_deployer.egg-info/requires.txt
@@ -31,6 +31,7 @@ py-multibase==1.0.1
 py-multicodec==0.2.1
 py-multihash==0.2.3
 py-solc==3.2.0
+py-solc-x==0.7.2
 pycryptodome==3.9.4
 pyrsistent==0.15.7
 pysha3==1.0.2
@@ -39,6 +40,7 @@ requests==2.22.0
 rlp==1.2.0
 semantic-version==2.8.4
 six==1.14.0
+solidity-unfolder==1.0.1
 toolz==0.10.0
 typing-extensions==3.7.4.1
 urllib3==1.25.7

--- a/cert_deployer/deploy.py
+++ b/cert_deployer/deploy.py
@@ -77,7 +77,7 @@ class ContractDeployer(object):
             opt = json.loads(raw_opt)
         #opt["sources"]["ResearchCertificate.sol"]["content"] = source_raw
         #compiled_sol = compile_source(source_raw)
-        compiled_sol = compile_files([tools.get_contr_path()], output_values=["abi", "bin"], solc_version="v" + self.app_config.compiler_version)
+        compiled_sol = compile_files([tools.get_contr_path()], output_values=["abi", "bin"])
         contract_interface = compiled_sol[tools.get_contr_path() + ":ResearchCertificate"]
         self.bytecode = contract_interface['bin']
         self.abi = contract_interface['abi']

--- a/conf_eth_template.ini
+++ b/conf_eth_template.ini
@@ -1,6 +1,6 @@
 deploying_address = <Your Ethereum address>
 
-chain = <ethereum_ropsten|ethereum_mainnet>
+chain = <ethereum_ropsten|ethereum_mainnet|bloxberg>
 node_url = <ethereum web3 public node url (e.g. infura)>
 
 ens_name = <Your ENS name registered with your ethereum address>


### PR DESCRIPTION
the `solc_version` parameter in `deploy.py` was causing an unexpected argument error. Removing the argument resolved the issue and still compiles with `0.6.2`. 